### PR TITLE
Added ability to handle SSM API Throttle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,17 @@ PASSWORD=productionpass
 SECRET_3=foobarbaz
 PASSWORD=stagingpass
 
-# filter by path (`/` will search all parameters)
-> AWS_REGION=<aws-region> aws-ssm-env --paths=/database
+# filter by path recursively (`/` will search all parameters)
+> AWS_REGION=<aws-region> aws-ssm-env --paths=/database --recursive
 PASSWORD=productionpass
 PASSWORD=stagingpass
 
+# filter by path non-recursively
+> AWS_REGION=<aws-region> aws-ssm-env --paths=/database
+# - this returns nothing
+
 # filter by path and tag
-> AWS_REGION=<aws-region> aws-ssm-env --paths=/database --tags=production
+> AWS_REGION=<aws-region> aws-ssm-env --paths=/database --tags=production --recursive
 PASSWORD=productionpass
 ```
 *Notice that parameter names are automatically capitalized.*

--- a/main.go
+++ b/main.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	client *ssm.SSM
-	paths  []string
-	tags   []string
+	client         *ssm.SSM
+	paths          []string
+	tags           []string
+	recursivePaths bool
 
 	falseBool     = false
 	trueBool      = true
@@ -53,10 +54,12 @@ func initClient() {
 func initFlags() {
 	pathsFlag := flag.String("paths", "", "comma delimited string of parameter path hierarchies")
 	tagsFlag := flag.String("tags", "", "comma delimited string of tags to filter by")
+	recursiveFlag := flag.Bool("recursive", false, "recurse through SSM heirarchy")
 	flag.Parse()
 
 	initPaths(pathsFlag)
 	initTags(tagsFlag)
+	recursivePaths = *recursiveFlag
 }
 
 func initPaths(pathsFlag *string) {
@@ -178,7 +181,7 @@ func getParamsByPath(paths []string) ([]*ssm.Parameter, error) {
 		for !done {
 			input := &ssm.GetParametersByPathInput{
 				Path:           &path,
-				Recursive:      &trueBool,
+				Recursive:      &recursivePaths,
 				WithDecryption: &trueBool,
 			}
 


### PR DESCRIPTION
Added primitive code to handle SSM API Throttle Exceptions. This was happening when multiple containers were trying to get parameters at the same time.

In addition, the DescribeParameters API call is only made if tags are specified on the command line. This reduces the execution duration if no tags are specified. It also makes it less likely that API throttles are reached.