### PR TITLE
Add ability to export params as env vars within application code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_Store
 main
+/bin
 /vendor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# credit: https://vic.demuzere.be/articles/golang-makefile-crosscompile/
+PLATFORMS := darwin/386 darwin/amd64 linux/386 linux/amd64 windows/386 windows/amd64
+
+checkenv:
+ifndef TAG
+	$(error release TAG is required - e.g v0.1.0)
+endif
+
+temp = $(subst /, ,$@)
+os = $(word 1, $(temp))
+arch = $(word 2, $(temp))
+name = aws-ssm-env
+longname = $(name)-$(TAG)-$(os)-$(arch)
+
+release: $(PLATFORMS)
+
+$(PLATFORMS): checkenv
+	GOOS=$(os) GOARCH=$(arch) go build -o 'bin/$(longname)/$(name)' main.go
+	cd bin/$(longname) && zip $(longname).zip $(name)
+
+.PHONY: checkenv release $(PLATFORMS) zip

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ Retrieve parameters with `aws-ssm-env`:
 > AWS_REGION=<aws-region> aws-ssm-env --paths=/ --tags=userservice,production
 SECRET_1=123456
 PASSWORD=productionpass
+
 # filter by 'accountservice' parameters for 'staging'
 > AWS_REGION=<aws-region> aws-ssm-env --paths=/ --tags=accountservice,staging
 SECRET_3=foobarbaz
 PASSWORD=stagingpass
+
 # filter by path (`/` will search all parameters)
 > AWS_REGION=<aws-region> aws-ssm-env --paths=/database
 PASSWORD=productionpass
 PASSWORD=stagingpass
+
 # filter by path and tag
 > AWS_REGION=<aws-region> aws-ssm-env --paths=/database --tags=production
 PASSWORD=productionpass

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ SECRET_2=abcdef
 ```
 *Notice that parameter names are automatically capitalized.*
 
-Multiple hierarchy paths can be passed in via `SSM_PATHS` (comma separated):
+Multiple hierarchy paths can be passed in `SSM_PATHS` (comma separated):
 ```
 > aws ssm put-parameter --name /production/app-1/SECRET_1 --value "123456" --type SecureString --key-id <kms-key-id> --region <aws-region>
 > aws ssm put-parameter --name /production/app-1/secret_2 --value "abcdef" --type SecureString --key-id <kms-key-id> --region <aws-region>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # aws-ssm-env
-Simple utility to print parameters from Amazon EC2 Systems Manager Parameter Store as environment variables. This is useful for injecting secure secrets into the environment of a docker container process.
+Simple utility to print parameters from Amazon EC2 Systems Manager (ssm) Parameter Store as environment variables. This is useful for injecting secure secrets into the environment of a docker container process.
 
 ### Usage
 Create secret parameters on AWS Parameter Store for your application using [hierarchies](http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-working.html#sysman-paramstore-su-organize):
@@ -9,7 +9,7 @@ Create secret parameters on AWS Parameter Store for your application using [hier
 ```
 Use `export` with `aws-ssm-env` to inject secrets from Parameter Store into the environment:
 ```
-> export $(AWS_REGION=<aws-region> aws-ssm-env -paths /production/app-1/)
+> export $(AWS_REGION=<aws-region> SSM_PATHS=/production/app-1/ aws-ssm-env)
 > env
 ...
 ...
@@ -18,12 +18,26 @@ SECRET_2=abcdef
 ```
 *Notice that parameter names are automatically capitalized.*
 
-Multiple hierarchy paths can be passed in via `-paths` (comma separated):
+Multiple hierarchy paths can be passed in via `SSM_PATHS` (comma separated):
 ```
 > aws ssm put-parameter --name /production/app-1/SECRET_1 --value "123456" --type SecureString --key-id <kms-key-id> --region <aws-region>
 > aws ssm put-parameter --name /production/app-1/secret_2 --value "abcdef" --type SecureString --key-id <kms-key-id> --region <aws-region>
 > aws ssm put-parameter --name /production/common/common_secret --value "foobarbaz" --type SecureString --key-id <kms-key-id> --region <aws-region>
-> export $(AWS_REGION=<aws-region> aws-ssm-env -paths /production/app-1/,/production/common/)
+> export $(AWS_REGION=<aws-region> SSM_PATHS=/production/app-1/,/production/common/ aws-ssm-env)
+> env
+...
+...
+SECRET_1=123456
+SECRET_2=abcdef
+COMMON_SECRET=foobarbaz
+```
+
+Paths can also be specified in `ssm_paths.txt` (`SSM_PATHS` takes precedence):
+```
+> cat ssm_paths.txt
+/production/app-1/
+/production/common/
+> export $(AWS_REGION=<aws-region> aws-ssm-env)
 > env
 ...
 ...
@@ -39,7 +53,7 @@ go get:
 ```
 Or download [binary](https://github.com/jamietsao/aws-ssm-env/releases/latest):
 ```
-> wget -O aws-ssm-env.zip https://github.com/jamietsao/aws-ssm-env/releases/download/v0.1.0/aws-ssm-env-v0.1.0-linux-amd64.zip
+> wget -O aws-ssm-env.zip https://github.com/jamietsao/aws-ssm-env/releases/download/v0.2.0/aws-ssm-env-v0.2.0-linux-amd64.zip
 > unzip aws-ssm-env.zip
 > chmod 755 aws-ssm-env
 ```

--- a/main.go
+++ b/main.go
@@ -53,8 +53,6 @@ func initPaths() {
 		paths = pathsFromFile(PATHS_FILE)
 	}
 
-	fmt.Println(paths)
-
 	// ensure only path hierarchies were given
 	for _, path := range paths {
 		if !strings.Contains(path, "/") {

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func initClient() {
 
 func initPaths() {
 	// SSM_PATHS env variable takes precedence
-	paths, exists := pathsFromEnv()
+	var exists bool
+	paths, exists = pathsFromEnv()
 
 	// if SSM_PATHS is not given, read paths from ssm_paths.txt file
 	if !exists {
@@ -63,34 +64,34 @@ func initPaths() {
 }
 
 func pathsFromFile(filename string) []string {
-	paths := make([]string, 0)
+	filePaths := make([]string, 0)
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return paths
+		return filePaths
 	}
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		paths = append(paths, scanner.Text())
+		filePaths = append(filePaths, scanner.Text())
 	}
 
-	return paths
+	return filePaths
 }
 
 func pathsFromEnv() ([]string, bool) {
-	var paths []string
+	var envPaths []string
 
-	envPaths, found := os.LookupEnv(PATHS_ENV)
+	envStr, found := os.LookupEnv(PATHS_ENV)
 	if !found {
-		return paths, false
+		return envPaths, false
 	}
 
-	if envPaths != "" {
-		paths = strings.Split(envPaths, ",")
+	if envStr != "" {
+		envPaths = strings.Split(envStr, ",")
 	}
-	return paths, true
+	return envPaths, true
 }
 
 func fetchParams(paths []string) ([]*ssm.Parameter, error) {


### PR DESCRIPTION
Merge the following two changes:

- Ability to export parameters as environment variables within application code: https://github.com/gametimesf/aws-ssm-env/pull/1
- Added optional `SSM_REGION` environment var for cases where application is running in a different region than the SSM params region: https://github.com/gametimesf/aws-ssm-env/pull/2